### PR TITLE
fix: add version to PR title

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -54,14 +54,14 @@ jobs:
 
       - name: Compile PR title
         run: |
-          # Get version from .release-version file
+          # Get version from .release-version file and append to title
 
-          if [ ! -f .release-version ]; then
-            # read the version from the file
+          TITLE="[release] Merge Develop into ${MAIN_BRANCH_NAME^}"
+
+          # Check the release version has changed and concat it
+          if [ -f .release-version ]; then
             VERSION=$(cat .release-version)
-            TITLE="[release] Merge Develop into ${MAIN_BRANCH_NAME^} for ${VERSION}"
-          else
-            TITLE="[release] Merge Develop into ${MAIN_BRANCH_NAME^}"
+            TITLE="${TITLE} for ${VERSION}"
           fi
 
       - name: Compile PR description


### PR DESCRIPTION
We now have automated release PRs, but they all have the same title...

This should help distinguish between PRs.

#### Changes proposed in this pull request

- Append the current version file contents to the PR title:
  **[release] Merge Develop into Main for 1.2.3**
  Note, the title will change when the `.release-version` is updated.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
