### PR TITLE
fix: add check for Closes text at start of PR body

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -44,7 +44,7 @@ jobs:
           # Sort extracted PR numbers by title
           SORTED_PR_NUMBERS=$(jq -r '.[].number' <<< "$PR_NUMBERS_AND_TITLES")
 
-          STORIES=$(xargs -I {} gh pr view {} --json body --jq '.body | if . | test("(?i)Closes #\\d+") then capture("(?i)Closes #(?<issue_number>\\d+)") | "- #{}
+          STORIES=$(xargs -I {} gh pr view {} --json body --jq '.body | if . | test("(?i)^Closes #\\d+") then capture("(?i)^Closes #(?<issue_number>\\d+)") | "- #{}
             - Closes #" + .issue_number else "- #{}" end' <<< "$SORTED_PR_NUMBERS") # Note the line-break on this line is for formatting
 
           # Format and output variable as a multiline string


### PR DESCRIPTION
Closes https://github.com/sanger/sequencescape/pull/4786#issuecomment-2782931147

#### Changes proposed in this pull request

- Adds regex check for the test string appearing at the start of the body

#### Instructions for Reviewers

Tested against https://github.com/sanger/.github/pull/2 with negligible edits ✅ 

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
