### PR TITLE
feat: add a production release label to release PRs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,5 @@
 # Create or update merge-to-main pull requests for production releases
+# PRs are created from develop into main (or master) as a draft and tagged with a 'production release' label
 # Note that by design, creating or editing a PR will not trigger a downstream `pull_request` event as this could lead to recursion
 name: Release
 on:
@@ -10,6 +11,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Create 'production release' label if it doesn't exist
+        env:
+          GH_TOKEN: ${{ github.token }} # required for gh cli
+        run: |
+          if ! gh label view "production release" >/dev/null 2>&1; then
+            gh label create "production release" -c "#08872B" -d "Pull requests for production release"
+            echo "Created 'production release' label"
+          else
+            echo "'production release' label already exists"
+          fi
 
       - name: Determine main branch name
         run: |
@@ -110,7 +122,7 @@ jobs:
           if [ -z "$EXISTING_PR" ]; then
             # Create a new PR
             PR_BODY="$DESCRIPTION"
-            gh pr create --base "$MAIN_BRANCH_NAME" --head develop --title "$PR_TITLE" --body "$PR_BODY" --draft
+            gh pr create --base "$MAIN_BRANCH_NAME" --head develop --title "$PR_TITLE" --body "$PR_BODY" --draft --label "production release"
           else
             # get the body of the existing PR
             EXISTING_PR_BODY=$(gh pr view "$EXISTING_PR" --json body --jq '.body')

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -16,11 +16,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }} # required for gh cli
         run: |
-          if ! gh label view "production release" >/dev/null 2>&1; then
-            gh label create "production release" -c "#08872B" -d "Pull requests for production release"
+          # Check if the label exists, and create it if it doesn't
+          if ! gh label list --json name | grep -q "production release"; then
+            gh label create "production release" --description "Pull requests for production release" --color "#0e8a16"
             echo "Created 'production release' label"
           else
-            echo "'production release' label already exists"
+            echo "Label 'production release' already exists"
           fi
 
       - name: Determine main branch name


### PR DESCRIPTION
Makes it easier to identify release PRs in the pull-request list

#### Changes proposed in this pull request

- Creates a green 'production release' label if one does not exist (in label default green)
- Tags new release PRs with the label

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
