### PR TITLE
fix: force creation of "production release" label

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -12,17 +12,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create 'production release' label if it doesn't exist
+      - name: Create 'production release' label
         env:
           GH_TOKEN: ${{ github.token }} # required for gh cli
         run: |
-          # Check if the label exists, and create it if it doesn't
-          if ! gh label list --json name | grep -q "production release"; then
-            gh label create "production release" --description "Pull requests for production release" --color "#0e8a16"
-            echo "Created 'production release' label"
-          else
-            echo "Label 'production release' already exists"
-          fi
+          gh label create "production release" --description "Pull requests for production release" --color "#0e8a16" --force
+          echo "Created 'production release' label"
 
       - name: Determine main branch name
         run: |


### PR DESCRIPTION
Create release PR actions are failing due to the label already existing (see #33) - not quite sure why since I tried to add a check for this, but it's probably much simpler all round if the label creation is forced (details overridden) instead.

#### Changes proposed in this pull request

- Simplify and force label creation

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
