### PR TITLE
fix: add skip-server flag to prevent infinite hangs on Rails 8

### DIFF
--- a/.github/actions/setup/env/action.yml
+++ b/.github/actions/setup/env/action.yml
@@ -23,7 +23,7 @@ runs:
         DBPORT: ${{ inputs.dbport }}
       run: |
         bundle config path vendor/bundle
-        bin/setup
+        bin/setup --skip-server
 
         if [ "${{ inputs.precompile }}" = "true" ]; then
           echo "Precompiling assets..."


### PR DESCRIPTION
Closes https://github.com/sanger/sequencescape/pull/5678

#### Changes proposed in this pull request

- Adds new `--skip-server` flag to prevent infinite hangs on Rails 8.x

The flag is ignored by older rails versions

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
