### PR TITLE
Fix GitHub duplicate auth header and node version

### DIFF
--- a/.github/actions/setup/checkout/action.yml
+++ b/.github/actions/setup/checkout/action.yml
@@ -1,5 +1,17 @@
 name: "Checkout Repository"
+description: "Checkout repository with optional GitHub token for authentication"
+inputs:
+  token:
+    description: "GitHub token for authentication"
+    required: false
+outputs:
+  ref:
+    description: "The branch or tag ref that was checked out"
+    value: ${{ steps.checkout.outputs.ref }}
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - id: checkout
+      uses: actions/checkout@v6
+      with:
+        token: ${{ inputs.token || github.token }}

--- a/.github/actions/setup/checkout/action.yml
+++ b/.github/actions/setup/checkout/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: "GitHub token for authentication"
     required: false
+  ref:
+    description: "Branch, tag, or SHA to checkout"
+    required: false
 outputs:
   ref:
     description: "The branch or tag ref that was checked out"
@@ -15,3 +18,4 @@ runs:
       uses: actions/checkout@v6
       with:
         token: ${{ inputs.token || github.token }}
+        ref: ${{ inputs.ref }}

--- a/.github/workflows/add_to_tech_debt_project_reusable.yml
+++ b/.github/workflows/add_to_tech_debt_project_reusable.yml
@@ -20,10 +20,15 @@ jobs:
     steps:
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v4
+        uses: actions/create-github-app-token@v3
         with:
-          application_id: ${{ secrets.app_id }}
-          application_private_key: ${{ secrets.app_key}}
+          client-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_key}}
+
+      - name: Checkout this repository
+        uses: sanger/.github/.github/actions/setup/checkout@master
+        with:
+          token: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: Use Application Token to add to project
         uses: actions/add-to-project@v2

--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -10,12 +10,10 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: sanger/.github/.github/actions/setup/checkout@master
-        with:
-          ref: ${{ github.head_ref }}
       - name: Check if .release-version file has changed
         run: |
-          git fetch origin ${{ github.base_ref }}
-          if ! git diff --name-only origin/${{ github.base_ref }} ${{ github.head_ref }} | grep -q '^\.release-version$'; then
+          git fetch origin "${{ github.base_ref }}"
+          if ! git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -q '^\.release-version$'; then
               echo "Please change the release version number"
               exit 1
           fi

--- a/.github/workflows/generate_issue_number.yml
+++ b/.github/workflows/generate_issue_number.yml
@@ -14,18 +14,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get token
+        id: get_workflow_token # Generates a token for the action
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_key }}
+
       - name: Checkout this repository
         uses: sanger/.github/.github/actions/setup/checkout@master
+        with:
+          token: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: Set issue prefix # Current year // Y24, Y25 etc
         run: echo "ISSUE_PREFIX=Y$(date +'%y')" >> $GITHUB_ENV
-
-      - name: Get token
-        id: get_workflow_token # Generates a token for the action
-        uses: peter-murray/workflow-application-token-action@v4
-        with:
-          application_id: ${{ secrets.app_id }}
-          application_private_key: ${{ secrets.app_key }}
 
       # Updates org variable for the counter & updates the issue title
       - name: Assign custom issue number

--- a/workflow-templates/update-rubocop.yml
+++ b/workflow-templates/update-rubocop.yml
@@ -30,7 +30,7 @@ jobs:
     if: (github.repository_owner == 'sanger') # On the sanger fork only
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       env:


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

##### 1. Prevent Duplicate Authorization Headers

Problem:
- Workflow generated a GitHub App token
- Checkout didn't know about this token, so it used the default GITHUB_TOKEN
- Git ended up with both tokens available for authentication
- Git sent credential headers for both -> duplicate Authorization headers -> 400 error

Fix:
- explicitly pass the GitHub App token to checkout
`token: ${{ steps.get_workflow_token.outputs.token }}`
- Checkout now knows: "Use this specific token, ignore the default GITHUB_TOKEN."

##### 2. Upgrade Actions to Node.js 24

Problem:
- GitHub removed Node.js 20 from Actions runners on June 16, 2026. The old actions the workflows were using run on Node.js 20, peter-murray/workflow-application-token-action@v4 and actions/checkout@v2 .
- When the runner tried to execute them -> Node.js 20 not found -> workflows fail

Fix:
- Upgrade to newer versions that run on Node.js 24: peter-murray/workflow-application-token-action@v4 -> actions/create-github-app-token@v3 and actions/checkout@v2 -> actions/checkout@v4
- Parameter names: application_id -> client-id and application_private_key -> private-key
- the output (steps.get_workflow_token.outputs.token) stays the same

##### 3. Fix release-version and checkout

Problem:
- The shared check-release-version workflow used ${{ github.head_ref }} as a branch argument in git diff
- In CI, that branch name is not always present as a local ref, causing failures like fatal: ambiguous argument 'develop'

Fix:
- Update shared workflow .github/workflows/check-release-version.yml to diff origin/${{ github.base_ref }} against checked-out HEAD instead of ${{ github.head_ref }}.
- Remove ref: ${{ github.head_ref }} from that workflow call
- Add optional ref input back to .github/actions/setup/checkout/action.yml and pass it to actions/checkout@v6 to keep backward compatibility.

References:
https://github.com/actions/create-github-app-token
https://github.com/actions/checkout
https://docs.github.com/actions/using-workflows/reusing-workflows
https://docs.github.com/actions/security-guides/encrypted-secrets
https://docs.github.com/actions/security-guides/automatic-token-authentication
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
